### PR TITLE
DATA-9857 Add release-and-build-docker caller workflow

### DIFF
--- a/.github/workflows/release-parascopy-docker.yaml
+++ b/.github/workflows/release-parascopy-docker.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       minor-release:
-        description: "Is this a patch release?"
+        description: "Is this a minor release?"
         type: boolean
         required: false
         default: false

--- a/.github/workflows/release-parascopy-docker.yaml
+++ b/.github/workflows/release-parascopy-docker.yaml
@@ -26,3 +26,4 @@ jobs:
       docker-image: parascopy
       minor-release: ${{ inputs.minor-release }}
       create-release: ${{ inputs.create-release }}
+      base-branch: "ilyasoifer/ug.tags"

--- a/.github/workflows/release-parascopy-docker.yaml
+++ b/.github/workflows/release-parascopy-docker.yaml
@@ -1,0 +1,28 @@
+name: Release and Build parascopy Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      minor-release:
+        description: "Is this a patch release?"
+        type: boolean
+        required: false
+        default: false
+      create-release:
+        description: "Create a GitHub Release?"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release-and-build:
+    uses: Ultimagen/ugbio-utils/.github/workflows/release-and-build-docker.yml@main
+    secrets: inherit
+    with:
+      docker-image: parascopy
+      minor-release: ${{ inputs.minor-release }}
+      create-release: ${{ inputs.create-release }}


### PR DESCRIPTION
## Summary
- Adds `release-parascopy-docker.yaml` workflow that calls the common `release-and-build-docker.yml` from ugbio-utils
- Automates: find latest semver tag → bump version → create tag → build docker

## Inputs
- `minor-release`: If true, bumps patch (1.0.0 → 1.0.1); otherwise bumps minor (1.0.0 → 1.1.0)
- `create-release`: If true, also creates a GitHub Release (not just a tag)

## Dependencies
- Requires https://github.com/Ultimagen/ugbio-utils/tree/DATA-9857-release-and-build-docker-workflow to be merged first